### PR TITLE
Adding Scout Walkers Techmarine Rhino and 2 named Wolflords

### DIFF
--- a/Aeldari_Craftworlds.cat
+++ b/Aeldari_Craftworlds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8438-2d0c-eaf9-6f84" name="Aeldari - Craftworlds" revision="2" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorContact="" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8438-2d0c-eaf9-6f84" name="Aeldari - Craftworlds" revision="3" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorContact="" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="280a-43bb-426c-aa7c" name="Asuryani Datasheets PDF"/>
   </publications>
@@ -88,6 +88,7 @@
     <categoryEntry id="d078-349c-734a-7db7" name="Corsair Voidscarred" hidden="false"/>
     <categoryEntry id="c033-4ec2-8f9b-f5a8" name="Shroud Runners" hidden="false"/>
     <categoryEntry id="a73a-db0f-8e67-2136" name="Yrrthilien Moursong" publicationId="3434-17b5-4a22-f338" hidden="false"/>
+    <categoryEntry id="d572-cf7a-4d18-7830" name="Scout Walkers" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="8785-9bd8-6adf-940c" name="Eldrad Ulthran" hidden="false" collective="false" import="true" targetId="e4e5-fffd-9435-163e" type="selectionEntry"/>
@@ -161,6 +162,7 @@
     <entryLink id="b4b7-63e6-98fb-c0ca" name="Shroud Runners" hidden="false" collective="false" import="true" targetId="30dd-ac10-f8b3-2c0c" type="selectionEntry"/>
     <entryLink id="0620-7889-ca15-374c" name="Yrrthilien Moursong [Legends]" hidden="false" collective="false" import="true" targetId="7513-db79-53cf-684a" type="selectionEntry"/>
     <entryLink id="e178-9f5d-a2af-09ac" name="Unit Filter" hidden="false" collective="false" import="true" targetId="5762-d38f-34fb-131a" type="selectionEntry"/>
+    <entryLink id="a6d5-8bcf-4d37-77ed" name="Scout Walkers [Legends]" hidden="false" collective="false" import="true" targetId="026b-dd8d-161f-f0df" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="e4e5-fffd-9435-163e" name="Eldrad Ulthran" publicationId="280a-43bb-426c-aa7c" page="1" hidden="false" collective="false" import="true" type="model">
@@ -7186,7 +7188,7 @@ weapons by this unit.</characteristic>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fc3c-ec64-146e-0f7b" name="Unit Size" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="fc3c-ec64-146e-0f7b" name="Unit Size" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" defaultSelectionEntryId="ce6d-3876-7c45-f1dc">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf0-4265-18e8-5f0c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cec-408a-f856-3fbb" type="max"/>
@@ -7444,6 +7446,155 @@ weapons by this unit.</characteristic>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="026b-dd8d-161f-f0df" name="Scout Walkers [Legends]" publicationId="8389-c75f-841c-95a7" hidden="false" collective="false" import="true" type="upgrade">
+      <comment>Taken from Citadel Journal #8</comment>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="20a7-9128-938d-97d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="9946-3ddd-15fb-aa3d" name="Infiltrators" publicationId="280a-43bb-426c-aa7c" hidden="false" targetId="f07d-6c22-ac83-604c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f0e7-fa14-8c76-caf2" name="New CategoryLink" hidden="false" targetId="3945-9603-5902-58c0" primary="true"/>
+        <categoryLink id="d8fa-1645-1a79-4e38" name="Faction: &lt;Craftworld&gt;" hidden="false" targetId="c595-6cad-4e25-eb78" primary="false"/>
+        <categoryLink id="2f61-3977-f2db-53fb" name="Faction: Asuryani" hidden="false" targetId="b3cf-7747-c0da-770b" primary="false"/>
+        <categoryLink id="dd08-c8fe-edf0-ae13" name="Faction: Aeldari" hidden="false" targetId="ce0a-bb90-8dd4-f52d" primary="false"/>
+        <categoryLink id="b46a-6ca2-2d05-f291" name="Heavy" hidden="false" targetId="25c7-3353-2028-72b2" primary="false"/>
+        <categoryLink id="f350-864a-5118-25a8" name="Vehicle" hidden="false" targetId="5aeb-0fa6-9427-2144" primary="false"/>
+        <categoryLink id="2c9b-a5a8-fcc3-db05" name="Scout Walkers" hidden="false" targetId="d572-cf7a-4d18-7830" primary="false"/>
+        <categoryLink id="db38-5161-a243-cf46" name="Faction: Warhost" hidden="false" targetId="426a-d6ae-7bf1-76e7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="41d2-b52b-522f-15a3" name="Armoured Feet" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0858-ff29-42e4-883e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc34-a62b-ef06-5b43" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2a96-d4e5-3832-ef53" name="Armoured Feet" publicationId="280a-43bb-426c-aa7c" hidden="false" typeId="c9f1-094d-9681-28f3" typeName="Weapons">
+              <characteristics>
+                <characteristic name="Type" typeId="359f-19b3-6670-21f5">Melee</characteristic>
+                <characteristic name="Range" typeId="bea7-7040-8485-6f0f">Melee</characteristic>
+                <characteristic name="A" typeId="2883-af07-d4e8-d8d0">User</characteristic>
+                <characteristic name="SAP" typeId="74b1-f85d-ede5-c758">10+</characteristic>
+                <characteristic name="SAT" typeId="4b6c-996a-d317-affb">10+</characteristic>
+                <characteristic name="Abilities" typeId="61ff-d2ec-f13b-06fa">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="55e3-47cd-8b13-a185" name="Unit Size" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" defaultSelectionEntryId="d476-8178-598d-65c3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cdc-1b68-6b79-52b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a221-67b9-9e21-5d64" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d476-8178-598d-65c3" name="1 Model" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee57-2675-e585-812a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="366e-4c53-22e5-0929" name="1 Model" publicationId="280a-43bb-426c-aa7c" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="606d-344a-bc3d-9dce">10&quot;</characteristic>
+                    <characteristic name="WS" typeId="e2a3-fade-c12d-860b">3+</characteristic>
+                    <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">3+</characteristic>
+                    <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">1</characteristic>
+                    <characteristic name="W" typeId="7c7f-f763-1f39-410c">1</characteristic>
+                    <characteristic name="Ld" typeId="91b0-3d37-1843-1290">6</characteristic>
+                    <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name=" PL" typeId="1466-da3f-0d27-dace" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9a40-84ec-c56f-06d2" name="2 Models" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74a6-692a-06ea-03b6" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="1748-cdc4-0f95-7d1a" name="2 Models" publicationId="280a-43bb-426c-aa7c" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="606d-344a-bc3d-9dce">10&quot;</characteristic>
+                    <characteristic name="WS" typeId="e2a3-fade-c12d-860b">3+</characteristic>
+                    <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">3+</characteristic>
+                    <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">2</characteristic>
+                    <characteristic name="W" typeId="7c7f-f763-1f39-410c">2</characteristic>
+                    <characteristic name="Ld" typeId="91b0-3d37-1843-1290">6</characteristic>
+                    <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name=" PL" typeId="1466-da3f-0d27-dace" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b97-133c-b1d2-f552" name="3 Models" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d5-aaad-941d-e029" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a9af-9f1e-4f50-6f22" name="3 Models" publicationId="280a-43bb-426c-aa7c" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="606d-344a-bc3d-9dce">10&quot;</characteristic>
+                    <characteristic name="WS" typeId="e2a3-fade-c12d-860b">3+</characteristic>
+                    <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">3+</characteristic>
+                    <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">3</characteristic>
+                    <characteristic name="W" typeId="7c7f-f763-1f39-410c">3</characteristic>
+                    <characteristic name="Ld" typeId="91b0-3d37-1843-1290">6</characteristic>
+                    <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name=" PL" typeId="1466-da3f-0d27-dace" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="dd53-b3c6-067f-b725" name="Weapon Options" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true">
+          <modifierGroups>
+            <modifierGroup>
+              <conditions>
+                <condition field="selections" scope="026b-dd8d-161f-f0df" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba72-4ef2-038d-cfa8" type="equalTo"/>
+              </conditions>
+              <modifiers>
+                <modifier type="set" field="95a0-efb5-92e9-b488" value="2.0"/>
+                <modifier type="set" field="e8ad-5803-5176-f6fc" value="2.0"/>
+              </modifiers>
+            </modifierGroup>
+            <modifierGroup>
+              <conditions>
+                <condition field="selections" scope="026b-dd8d-161f-f0df" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8a5-1355-2bd5-9ae4" type="equalTo"/>
+              </conditions>
+              <modifiers>
+                <modifier type="set" field="e8ad-5803-5176-f6fc" value="3.0"/>
+                <modifier type="set" field="95a0-efb5-92e9-b488" value="3.0"/>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a0-efb5-92e9-b488" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ad-5803-5176-f6fc" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fa89-a650-cd1a-12d6" name="Bright Lance" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" targetId="48e5-6b9d-8c24-42bd" type="selectionEntry"/>
+            <entryLink id="4e68-889a-d6bc-db57" name="Scatter Laser" publicationId="280a-43bb-426c-aa7c" hidden="false" collective="false" import="true" targetId="0ed2-0608-7a18-bbb8" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Imperium_Adeptus_Astartes.cat
+++ b/Imperium_Adeptus_Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ba6e-f4e4-9c13-bd4c" name="Imperium - Adeptus Astartes" revision="1" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ba6e-f4e4-9c13-bd4c" name="Imperium - Adeptus Astartes" revision="2" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6268-f517-c933-bf19" name="Faction: Adeptus Astartes" hidden="false"/>
     <categoryEntry id="51a9-73ff-29ec-793c" name="Tactical Squad" hidden="false"/>
@@ -5644,6 +5644,17 @@ friendly IMPERIAL FISTS units that target VEHICLE or BUILDING units.</characteri
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8fec-09da-d666-b444" name="Unit Filter" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="6b76-c399-f8d8-5b1d" name="List Configuration" hidden="false" targetId="b1fd-719c-4789-4656" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="477e-7c00-a516-a999" name="Hide Legacy units" hidden="false" collective="false" import="true" targetId="11d3-638c-0b29-a36c" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="fc3d-dd60-37ea-c9ef" name="Tactical Squad" hidden="false" collective="false" import="true" targetId="1fa2-88c4-2c7e-5d33" type="selectionEntry">
@@ -6512,6 +6523,34 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
       </categoryLinks>
     </entryLink>
     <entryLink id="91e1-25e5-60fd-d507" name="Roboute Guilliman" hidden="false" collective="false" import="true" targetId="c56d-6b51-dcaa-a08a" type="selectionEntry"/>
+    <entryLink id="753a-4249-04e7-dc3f" name="Techmarine Rhino [Legends]" hidden="false" collective="false" import="true" targetId="6afe-3e6a-fcd8-76bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="11d3-638c-0b29-a36c" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="7591-992d-3828-9cf1" name="Battlesmith" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">At the end of the Action phase, this unit can attempt to repair one friendly &lt;CHAPTER&gt; VEHICLE unit in base contact with it. If it does, roll one D6; on a 4+ remove one damage marker from that VEHICLE unit. Only one attempt to repair each unit can be made each turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7ea8-3e7f-bd47-e075" name="Techmarine Rhino" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">This unit can transport up to 6 friendly &lt;CHAPTER&gt; INFANTRY models. It cannot transport PRIMARIS, TERMINATOR, CENTURION or JUMP PACK units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="72ef-6903-e084-7949" name="Elites" hidden="false" targetId="8f90-47d8-c075-cbb2" primary="true"/>
+        <categoryLink id="6671-7b21-2014-3108" name="Faction: &lt;CHAPTER&gt;" hidden="false" targetId="fe0e-e179-5b4e-c377" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
+      </costs>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c56d-6b51-dcaa-a08a" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="unit">
@@ -6629,6 +6668,14 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="11d3-638c-0b29-a36c" name="Hide Legacy units" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f9-7a54-18d8-8d57" type="max"/>
+      </constraints>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Imperium_Astra_Militarum.cat
+++ b/Imperium_Astra_Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ed62-9ebb-f4c8-dd03" name="Imperium - Astra Militarum" revision="3" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ed62-9ebb-f4c8-dd03" name="Imperium - Astra Militarum" revision="3" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="b6a1-41e3-5fe3-e661" name="Lord Castellan Creed" hidden="false"/>
     <categoryEntry id="b0a1-41e3-5fe3-e661" name="Colour Sergeant Kell" hidden="false"/>
@@ -89,8 +89,8 @@
     <categoryEntry id="aebc-fe1c-b0e7-26c1" name="Battle Tank" hidden="false"/>
     <categoryEntry id="90e8-4bf4-5119-063b" name="Hellhound" hidden="false"/>
     <categoryEntry id="7b10-8288-447c-b8b1" name="Faction: Astra Militarum" hidden="false"/>
-    <categoryEntry id="f9db-fde0-9efb-2594" name="Cyllarus Armoured Car" publicationId="3434-17b5-4a22-f338" hidden="false"/>
-    <categoryEntry id="53b8-c6df-785d-1679" name="Asterion Command Vehicle" hidden="false"/>
+    <categoryEntry id="f9db-fde0-9efb-2594" name="Cyllarus Armoured Car" publicationId="8389-c75f-841c-95a7" hidden="false"/>
+    <categoryEntry id="53b8-c6df-785d-1679" name="Asterion Command Vehicle" publicationId="8389-c75f-841c-95a7" hidden="false"/>
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="1df4-025c-99c1-3120" name="Hades Breaching Drill" hidden="false" collective="false" import="true" type="upgrade">
@@ -6430,7 +6430,7 @@ When targets would be picked for a Fight action made by this unit, it instead ta
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a87b-8829-692e-03c2" name="Asterion Command Vehicle [Legends]" publicationId="3434-17b5-4a22-f338" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a87b-8829-692e-03c2" name="Asterion Command Vehicle [Legends]" publicationId="8389-c75f-841c-95a7" hidden="false" collective="false" import="true" type="upgrade">
       <comment>Taken from Citadel Journal #15 renamed from Minotaur to avoid confusion with the FW vehicle of the same name</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="true">

--- a/Imperium_Blood_Angels.cat
+++ b/Imperium_Blood_Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="bc93-92f0-5311-32d4" name="Imperium - Blood Angels" revision="1" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://discord.gg/3QtaU2g" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="bc93-92f0-5311-32d4" name="Imperium - Blood Angels" revision="2" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://discord.gg/3QtaU2g" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6268-f517-c933-bf19" name="Faction: Adeptus Astartes" hidden="false"/>
     <categoryEntry id="51a9-73ff-29ec-793c" name="Tactical Squad" hidden="false"/>
@@ -1731,6 +1731,17 @@
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="c666-5531-ec98-8388" name="Unit Filter" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="52c7-fac2-6925-a7d6" name="List Configuration" hidden="false" targetId="b1fd-719c-4789-4656" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="12ff-832e-e14f-e1df" name="Hide Legacy units" hidden="false" collective="false" import="true" targetId="9146-42a8-719f-b70b" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="fc3d-dd60-37ea-c9ef" name="Tactical Squad" hidden="false" collective="false" import="true" targetId="1fa2-88c4-2c7e-5d33" type="selectionEntry">
@@ -2685,6 +2696,34 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
         <categoryLink id="0d27-4d23-9fa8-2c6b" name="Faction: Blood Angels" hidden="false" targetId="f7a9-266d-efb6-d80f" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="6e98-8aa5-4a87-ea2e" name="Techmarine Rhino [Legends]" hidden="false" collective="false" import="true" targetId="6afe-3e6a-fcd8-76bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9146-42a8-719f-b70b" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="0d06-459f-10af-c89e" name="Battlesmith" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">At the end of the Action phase, this unit can attempt to repair one friendly BLOOD ANGELS VEHICLE unit in base contact with it. If it does, roll one D6; on a 4+ remove one damage marker from that VEHICLE unit. Only one attempt to repair each unit can be made each turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b3c5-db5f-d548-b8f2" name="Techmarine Rhino" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">This unit can transport up to 6 friendly BLOOD ANGELS INFANTRY models. It cannot transport PRIMARIS, TERMINATOR or JUMP PACK units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="9d07-b9e0-4bb0-ecc5" name="Elites" hidden="false" targetId="8f90-47d8-c075-cbb2" primary="true"/>
+        <categoryLink id="ec22-b4ed-d3be-9070" name="Faction: Blood Angels" hidden="false" targetId="f7a9-266d-efb6-d80f" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
+      </costs>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ec11-15ce-8b1a-62a9" name="Dead Man&apos;s Hand" hidden="false" collective="false" import="true" type="upgrade">
@@ -2740,6 +2779,14 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9146-42a8-719f-b70b" name="Hide Legacy units" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="167a-f0fa-3cd2-461f" type="max"/>
+      </constraints>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>

--- a/Imperium_Dark_Angels.cat
+++ b/Imperium_Dark_Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7774-c573-6697-5bd1" name="Imperium - Dark Angels" revision="11" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://discord.gg/3QtaU2g" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7774-c573-6697-5bd1" name="Imperium - Dark Angels" revision="12" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://discord.gg/3QtaU2g" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6268-f517-c933-bf19" name="Faction: Adeptus Astartes" hidden="false"/>
     <categoryEntry id="51a9-73ff-29ec-793c" name="Tactical Squad" hidden="false"/>
@@ -26,6 +26,19 @@
     <categoryEntry id="3600-450b-a555-569e" name="Lazarus" hidden="false"/>
     <categoryEntry id="d537-b50c-719d-d101" name="Inner Circle" hidden="false"/>
   </categoryEntries>
+  <selectionEntries>
+    <selectionEntry id="a56e-faa1-4102-8b59" name="Unit Filter" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ec5c-cdbb-bb01-e3ae" name="List Configuration" hidden="false" targetId="b1fd-719c-4789-4656" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8e33-d96b-5a28-5656" name="Hide Legacy units" hidden="false" collective="false" import="true" targetId="9608-768c-3955-8adf" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
   <entryLinks>
     <entryLink id="fc3d-dd60-37ea-c9ef" name="Tactical Squad" hidden="false" collective="false" import="true" targetId="1fa2-88c4-2c7e-5d33" type="selectionEntry">
       <categoryLinks>
@@ -977,6 +990,34 @@ Each TERMINATOR and JUMP PACK model takes the space of 2 other INFANTRY models a
       <infoLinks>
         <infoLink id="e6e6-6c61-bef7-9c85" name="Rites of Battle" hidden="false" targetId="a9a4-c13f-702f-4bae" type="profile"/>
       </infoLinks>
+    </entryLink>
+    <entryLink id="692c-71ce-077b-9b78" name="Techmarine Rhino [Legends]" hidden="false" collective="false" import="true" targetId="6afe-3e6a-fcd8-76bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9608-768c-3955-8adf" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="e445-fc57-b171-eddb" name="Battlesmith" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">At the end of the Action phase, this unit can attempt to repair one friendly DARK ANGELS VEHICLE unit in base contact with it. If it does, roll one D6; on a 4+ remove one damage marker from that VEHICLE unit. Only one attempt to repair each unit can be made each turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cce2-2e4c-205a-acc1" name="Techmarine Rhino" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">This unit can transport up to 6 friendly DARK ANGELS INFANTRY models. It cannot transport PRIMARIS, TERMINATOR or JUMP PACK units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="9779-44bf-158d-54dd" name="Elites" hidden="false" targetId="8f90-47d8-c075-cbb2" primary="true"/>
+        <categoryLink id="47cb-bd2b-5ca7-da18" name="Faction: Dark Angels" hidden="false" targetId="6ac9-811a-fe59-5de1" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
+      </costs>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -2944,6 +2985,14 @@ Each TERMINATOR and JUMP PACK model takes the space of 2 other INFANTRY models a
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9608-768c-3955-8adf" name="Hide Legacy units" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2631-a995-2fe7-11a8" type="max"/>
+      </constraints>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Imperium_Space_Wolves.cat
+++ b/Imperium_Space_Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="61c5-1517-db5f-03f8" name="Imperium - Space Wolves" revision="1" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="61c5-1517-db5f-03f8" name="Imperium - Space Wolves" revision="2" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse" library="false" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6268-f517-c933-bf19" name="Faction: Adeptus Astartes" hidden="false"/>
     <categoryEntry id="51a9-73ff-29ec-793c" name="Tactical Squad" hidden="false"/>
@@ -51,6 +51,8 @@
     <categoryEntry id="f66b-11b4-5daf-9b88" name="Stormwolf" hidden="false"/>
     <categoryEntry id="0d3d-523e-d125-51bc" name="Swiftclaw" hidden="false"/>
     <categoryEntry id="0fbe-d451-d2b1-902c" name="Hounds of Morkai" hidden="false"/>
+    <categoryEntry id="03f3-aad5-6a83-be51" name="Kvalnir Silverclaw" publicationId="8389-c75f-841c-95a7" hidden="false"/>
+    <categoryEntry id="0b50-cac3-f18f-dea8" name="Berek Thunderfist" publicationId="8389-c75f-841c-95a7" hidden="false"/>
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="b86f-f535-5a4e-c796" name="Logan Grimnar" hidden="false" collective="false" import="true" type="unit">
@@ -4875,6 +4877,155 @@ Additionally, when this unit makes a Fight action, add 1 to hit rolls and you ca
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="9b23-1902-9af7-9b96" name="Berek Thunderfist [Legends]" publicationId="8389-c75f-841c-95a7" hidden="false" collective="false" import="true" type="upgrade">
+      <comment>Taken from Citadel Journal #2</comment>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a8d6-5576-7ba9-f3ae" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="258e-44e1-d0bb-a873" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d98d-9af7-a121-1a6a" name="Berek Thunderfist" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="606d-344a-bc3d-9dce">6&quot;</characteristic>
+            <characteristic name="WS" typeId="e2a3-fade-c12d-860b">2+</characteristic>
+            <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">2+</characteristic>
+            <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">1</characteristic>
+            <characteristic name="W" typeId="7c7f-f763-1f39-410c">1</characteristic>
+            <characteristic name="Ld" typeId="91b0-3d37-1843-1290">7</characteristic>
+            <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">5+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="41d7-4b8e-84e5-dcc1" name="Jarl of Fenris" hidden="false" targetId="bdcc-f69f-afe1-a2a5" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="58b6-dfeb-58ca-178c" name="New CategoryLink" hidden="false" targetId="08d9-07e5-2b35-57b0" primary="true"/>
+        <categoryLink id="0210-e058-93bf-5d7d" name="Faction: Imperium" hidden="false" targetId="e30a-8f35-5fe6-534d" primary="false"/>
+        <categoryLink id="833b-a369-d8ed-190b" name="Faction: Adeptus Astartes" hidden="false" targetId="6268-f517-c933-bf19" primary="false"/>
+        <categoryLink id="4da0-c3e7-e29d-e15e" name="Faction: Space Wolves" hidden="false" targetId="58c1-00b9-7a20-4110" primary="false"/>
+        <categoryLink id="7f28-030b-b148-e490" name="Light" hidden="false" targetId="7eb1-73ba-2de4-ca9b" primary="false"/>
+        <categoryLink id="1d34-1e13-99fd-a0e1" name="Character" hidden="false" targetId="4b9a-33b1-3b42-e3f8" primary="false"/>
+        <categoryLink id="5669-4868-dbe0-d062" name="Berek Thunderfist" hidden="false" targetId="0b50-cac3-f18f-dea8" primary="false"/>
+        <categoryLink id="58f4-348f-fb43-d320" name="Wolf Lord" hidden="false" targetId="949a-c2a1-40fa-aa09" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e615-2f5a-0a23-683e" name="Claws of theThundewolf" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e173-611d-b202-77fc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b3-90c2-dea1-8ee5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c18f-c7c4-0c96-5d55" name="Claws of theThundewolf" hidden="false" typeId="c9f1-094d-9681-28f3" typeName="Weapons">
+              <characteristics>
+                <characteristic name="Type" typeId="359f-19b3-6670-21f5">Melee</characteristic>
+                <characteristic name="Range" typeId="bea7-7040-8485-6f0f">Melee</characteristic>
+                <characteristic name="A" typeId="2883-af07-d4e8-d8d0">User</characteristic>
+                <characteristic name="SAP" typeId="74b1-f85d-ede5-c758">7+</characteristic>
+                <characteristic name="SAT" typeId="4b6c-996a-d317-affb">7+</characteristic>
+                <characteristic name="Abilities" typeId="61ff-d2ec-f13b-06fa">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="53cf-26b5-e37a-91c3" name="Commander" hidden="false" collective="false" import="true" targetId="7347-5716-355f-9165" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b7a6-f2cf-793a-907b" name="Kvalnir Silverclaw [Legends]" publicationId="8389-c75f-841c-95a7" hidden="false" collective="false" import="true" type="upgrade">
+      <comment>Taken from Citadel Journal #2</comment>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a8d6-5576-7ba9-f3ae" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce30-3b68-6198-3379" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6ad0-aba4-2658-3e72" name="Kvalnir Silverclaw" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="606d-344a-bc3d-9dce">5&quot;</characteristic>
+            <characteristic name="WS" typeId="e2a3-fade-c12d-860b">2+</characteristic>
+            <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">2+</characteristic>
+            <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">1</characteristic>
+            <characteristic name="W" typeId="7c7f-f763-1f39-410c">1</characteristic>
+            <characteristic name="Ld" typeId="91b0-3d37-1843-1290">7</characteristic>
+            <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">4+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="83f4-e216-790c-8000" name="Jarl of Fenris" hidden="false" targetId="bdcc-f69f-afe1-a2a5" type="profile"/>
+        <infoLink id="5806-e954-d1e7-240d" name="Deep Strike" hidden="false" targetId="8fc3-5045-3aa5-00ce" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="42d9-bfa0-89dc-b1fb" name="New CategoryLink" hidden="false" targetId="08d9-07e5-2b35-57b0" primary="true"/>
+        <categoryLink id="9725-e117-b556-c645" name="Faction: Imperium" hidden="false" targetId="e30a-8f35-5fe6-534d" primary="false"/>
+        <categoryLink id="e00e-659a-9a02-3adb" name="Faction: Adeptus Astartes" hidden="false" targetId="6268-f517-c933-bf19" primary="false"/>
+        <categoryLink id="4ec2-4dae-7e89-198d" name="Faction: Space Wolves" hidden="false" targetId="58c1-00b9-7a20-4110" primary="false"/>
+        <categoryLink id="812d-6d7f-5afb-6e31" name="Light" hidden="false" targetId="7eb1-73ba-2de4-ca9b" primary="false"/>
+        <categoryLink id="24c0-a078-0258-1d96" name="Character" hidden="false" targetId="4b9a-33b1-3b42-e3f8" primary="false"/>
+        <categoryLink id="49c6-e0d4-6817-711a" name="Terminator" hidden="false" targetId="3726-f1d3-1b96-0eb0" primary="false"/>
+        <categoryLink id="8ec2-8ee0-9252-4369" name="Kvalnir Silverclaw" hidden="false" targetId="03f3-aad5-6a83-be51" primary="false"/>
+        <categoryLink id="21e5-412c-d8ed-2414" name="Wolf Lord" hidden="false" targetId="949a-c2a1-40fa-aa09" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a9fb-6312-c59c-a97e" name="The Long Fang" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2ef-d3ac-165f-a150" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1b-4fbc-6e33-2053" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3507-b84b-d1bb-9207" name="The Long Fang" hidden="false" typeId="c9f1-094d-9681-28f3" typeName="Weapons">
+              <characteristics>
+                <characteristic name="Type" typeId="359f-19b3-6670-21f5">Melee</characteristic>
+                <characteristic name="Range" typeId="bea7-7040-8485-6f0f">Melee</characteristic>
+                <characteristic name="A" typeId="2883-af07-d4e8-d8d0">User</characteristic>
+                <characteristic name="SAP" typeId="74b1-f85d-ede5-c758">7+</characteristic>
+                <characteristic name="SAT" typeId="4b6c-996a-d317-affb">7+</characteristic>
+                <characteristic name="Abilities" typeId="61ff-d2ec-f13b-06fa">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="556a-7609-5c8e-3258" name="Commander" hidden="false" collective="false" import="true" targetId="7347-5716-355f-9165" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="7.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="44cb-40c5-11d6-5e13" name="Unit Filter" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b912-99df-3f23-8a7c" name="List Configuration" hidden="false" targetId="b1fd-719c-4789-4656" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="49fe-d8b0-0550-2d1b" name="Hide Legacy units" hidden="false" collective="false" import="true" targetId="a8d6-5576-7ba9-f3ae" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="b768-96a2-3723-ce3d" name="Rhino Primaris" hidden="false" collective="false" import="true" targetId="6fdd-0f7d-c487-6743" type="selectionEntry">
@@ -5690,6 +5841,34 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
       </categoryLinks>
     </entryLink>
     <entryLink id="00c4-26f7-f2af-791a" name="Relic Sicaran Omega Tank Destroyer" hidden="false" collective="false" import="true" targetId="1b61-539d-610c-1928" type="selectionEntry"/>
+    <entryLink id="1cf9-1d2d-e194-318a" name="Techmarine Rhino [Legends]" hidden="false" collective="false" import="true" targetId="6afe-3e6a-fcd8-76bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a8d6-5576-7ba9-f3ae" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="edba-7e32-7693-e85f" name="Battlesmith" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">At the end of the Action phase, this unit can attempt to repair one friendly SPACE WOLVES VEHICLE unit in base contact with it. If it does, roll one D6; on a 4+ remove one damage marker from that VEHICLE unit. Only one attempt to repair each unit can be made each turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8fda-7668-6536-a7db" name="Techmarine Rhino" hidden="false" typeId="5dca-db35-b3d1-ce65" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="6948-e9fe-7eb0-b8be">This unit can transport up to 6 friendly SPACE WOLVES INFANTRY models. It cannot transport PRIMARIS, TERMINATOR, WULFEN or JUMP PACK units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="327a-6e48-df28-dd7a" name="Elites" hidden="false" targetId="8f90-47d8-c075-cbb2" primary="true"/>
+        <categoryLink id="a086-e816-895f-1b5c" name="Faction: Space Wolves" hidden="false" targetId="58c1-00b9-7a20-4110" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
+      </costs>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a123-b4e9-1693-784f" name="The Axe Morkai" hidden="false" collective="false" import="true" type="upgrade">
@@ -5779,6 +5958,14 @@ LAND RAIDER, RELIC SPARTAN ASSAULT TANK, RHINO and RAZORBACK models can transpor
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a8d6-5576-7ba9-f3ae" name="Hide Legacy units" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b424-5bb5-3a59-5ec1" type="max"/>
+      </constraints>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
       </costs>

--- a/Library_Space_Marines.cat
+++ b/Library_Space_Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="98c2-e7ca-4cd2-d189" name="Library - Space Marines" revision="1" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse/" library="true" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="98c2-e7ca-4cd2-d189" name="Library - Space Marines" revision="2" battleScribeVersion="2.03" authorName="Th3Proj3ct" authorUrl="https://github.com/th3proj3ct/wh40k-fundapocalypse/" library="true" gameSystemId="01ba-02e5-cb5e-29f5" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6268-f517-c933-bf19" name="Faction: Adeptus Astartes" hidden="false"/>
     <categoryEntry id="51a9-73ff-29ec-793c" name="Tactical Squad" hidden="false"/>
@@ -141,6 +141,7 @@
     <categoryEntry id="399c-b44c-cfa9-b8c1" name="Hailstrike" hidden="false"/>
     <categoryEntry id="1762-9303-f65e-d6de" name="Thunderstrike" hidden="false"/>
     <categoryEntry id="2c2c-ac12-de58-4f4e" name="Hammerstrike" hidden="false"/>
+    <categoryEntry id="aa70-d80a-b829-532a" name="Techmarine Rhino" publicationId="8389-c75f-841c-95a7" hidden="false"/>
   </categoryEntries>
   <rules>
     <rule id="d3fe-d179-4b39-60b7" name="And They Shall Know No Fear" hidden="false">
@@ -13333,6 +13334,86 @@ that target this unit.</characteristic>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="1466-da3f-0d27-dace" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6afe-3e6a-fcd8-76bf" name="Techmarine Rhino [Legends]" publicationId="8df9-0b3e-abea-3c15" hidden="false" collective="false" import="true" type="unit">
+      <comment>Taken from Citadel Journal #7</comment>
+      <profiles>
+        <profile id="d709-53b3-f06d-49ac" name="Techmarine Rhino" hidden="false" typeId="758b-2459-9a46-721a" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="606d-344a-bc3d-9dce">12&quot;</characteristic>
+            <characteristic name="WS" typeId="e2a3-fade-c12d-860b">6+</characteristic>
+            <characteristic name="BS" typeId="bcfe-d5af-2691-5c77">3+</characteristic>
+            <characteristic name="A" typeId="ddfe-6a9e-32c1-a51c">1</characteristic>
+            <characteristic name="W" typeId="7c7f-f763-1f39-410c">2</characteristic>
+            <characteristic name="Ld" typeId="91b0-3d37-1843-1290">6</characteristic>
+            <characteristic name="Sv" typeId="a56f-38ae-3917-aadc">6+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="c26c-9053-be2d-c272" name="Faction: Imperium" hidden="false" targetId="e30a-8f35-5fe6-534d" primary="false"/>
+        <categoryLink id="eb29-c12a-d5ed-2774" name="Faction: Adeptus Astartes" hidden="false" targetId="6268-f517-c933-bf19" primary="false"/>
+        <categoryLink id="46e5-07ca-f478-6aa6" name="Vehicle" hidden="false" targetId="5aeb-0fa6-9427-2144" primary="false"/>
+        <categoryLink id="5e34-d604-6ad5-3b73" name="Transport" hidden="false" targetId="6f18-a45e-43de-b8b8" primary="false"/>
+        <categoryLink id="a70c-6e5a-b5f7-6506" name="Heavy" hidden="false" targetId="25c7-3353-2028-72b2" primary="false"/>
+        <categoryLink id="7c1b-8379-0542-64ca" name="Techmarine Rhino" hidden="false" targetId="aa70-d80a-b829-532a" primary="false"/>
+        <categoryLink id="7b16-ddf8-6ac5-5376" name="Elites" hidden="false" targetId="8f90-47d8-c075-cbb2" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f578-d993-da9a-e06e" name="Magna-beam" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a25-a1c2-dbf6-ec62" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8acf-05ee-7433-6102" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ce99-7aa1-deec-7a1b" name="Magna-beam" hidden="false" typeId="c9f1-094d-9681-28f3" typeName="Weapons">
+              <characteristics>
+                <characteristic name="Type" typeId="359f-19b3-6670-21f5">Heavy</characteristic>
+                <characteristic name="Range" typeId="bea7-7040-8485-6f0f">6&quot;</characteristic>
+                <characteristic name="A" typeId="2883-af07-d4e8-d8d0">1</characteristic>
+                <characteristic name="SAP" typeId="74b1-f85d-ede5-c758">10+</characteristic>
+                <characteristic name="SAT" typeId="4b6c-996a-d317-affb">4+</characteristic>
+                <characteristic name="Abilities" typeId="61ff-d2ec-f13b-06fa">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca86-d2ed-62eb-a727" name="Crusher Claw" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7e2-1e17-aa14-3ec4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a9e-9578-cb94-0e3e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="32e5-4602-57cd-01dd" name="Crusher Claw" hidden="false" typeId="c9f1-094d-9681-28f3" typeName="Weapons">
+              <characteristics>
+                <characteristic name="Type" typeId="359f-19b3-6670-21f5">Melee</characteristic>
+                <characteristic name="Range" typeId="bea7-7040-8485-6f0f">Melee</characteristic>
+                <characteristic name="A" typeId="2883-af07-d4e8-d8d0">User</characteristic>
+                <characteristic name="SAP" typeId="74b1-f85d-ede5-c758">6+</characteristic>
+                <characteristic name="SAT" typeId="4b6c-996a-d317-affb">6+</characteristic>
+                <characteristic name="Abilities" typeId="61ff-d2ec-f13b-06fa">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="1466-da3f-0d27-dace" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="de61-3c5d-4389-d001" name="Storm Bolter" hidden="false" collective="false" import="true" targetId="7457-58c5-d5f1-11a0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5a-5112-d464-86ab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="814d-e8d0-0a73-b16d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="1466-da3f-0d27-dace" value="8.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>


### PR DESCRIPTION
Added 

- Scout Walkers to Craftworlds
- Fixed default selection on Shroud Runners
- Fixed some publication ids in Astra Militarum - haven't bumped the version here as I'll be doing more work in the next commit, so will bump that then
- Added Techmarine Rhino to Marines, Blood Angels, Dark Angels and Space Wolves
- Added 2 named Wolf Lords to Space Wolves